### PR TITLE
Prevent responsiveness testing iframe from flickering

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,15 @@
       body {
         padding-top: 60px; /* 60px to make the container go all the way to the bottom of the topbar */
       }
+      #presentation-area {
+        width: 100%;
+        height: 180px;
+      }
+      #responsiveness-frame {
+        width: 100%;
+        height: 90%;
+        border: none;
+      }
     </style>
     <link href="css/bootstrap-responsive.min.css" rel="stylesheet">
 


### PR DESCRIPTION
This is a bit hacky in that the `before` callback isn't really something the system is set up for, but it works quite nice in practice.
