### PR TITLE
Redesign

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,0 +1,530 @@
+* {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+a:not([href]) {
+  cursor: pointer;
+}
+
+.hidden {
+  display: none;
+}
+
+html, body {
+  height: 100%;
+}
+
+body {
+  background: #fff;
+  color: #333;
+  font: 16px "Source Sans Pro", sans-serif;
+  min-width: 960px;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-size: 100%;
+}
+
+h1 {
+  font-size: 32px;
+}
+
+h2 {
+  color: #111;
+  font-size: 42px;
+  font-weight: 300;
+  line-height: 48px;
+  margin-bottom: 10px;
+}
+
+h3 {
+  color: darkcyan;
+  font-size: 24px;
+  font-weight: 500;
+  line-height: 28px;
+}
+
+.slogan {
+  display: block;
+  font-size: 32px;
+  font-weight: 500;
+  padding-left: 155px;
+}
+
+.prose {
+  line-height: 1.5;
+}
+
+.prose h2,
+.prose h3,
+.prose p {
+  margin: 20px 0;
+}
+
+.prose h2:first-child,
+.prose p:first-child {
+  margin-top: 0;
+}
+
+.prose ul {
+  margin: 0 0 20px 40px;
+}
+
+.prose li + li {
+  margin-top: 15px;
+}
+
+p + p {
+  margin-top: 20px;
+}
+
+a {
+  padding-bottom: 2px;
+  text-decoration: none;
+  transition: border-bottom .05s ease-in-out, color .05s ease-in-out;
+}
+
+.prose a {
+  border-bottom: 1px solid #eee;
+  color: #07d;
+}
+
+.prose a:active {
+  border-bottom-color: #fed;
+  color: #f81;
+}
+
+.prose a:hover {
+  border-bottom-color: #9cf;
+  color: #0ae;
+}
+
+@media (max-width: 320px) {
+  body {
+    padding: 0;
+  }
+}
+
+.flex {
+  display: -webkit-box;   /* iOS 6-, Safari 3.1-6 */
+  display: -moz-box;      /* Firefox 2-21 */
+  display: -ms-flexbox;   /* IE 10+ */
+  display: -webkit-flex;  /* Chrome 4-20 */
+  display: flex;          /* Chrome 21+, Firefox 20+, Opera 12.1 */
+}
+
+.flex-1 {
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+  -moz-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.vcentre {
+  /* Vertically centre with old flexbox */
+  -webkit-align-items: center;
+  -moz-box-align: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+
+  /* Vertically centre with new flexbox */
+  align-items: center;
+}
+
+.header {
+  background: rgba(187,221,255,.75);
+  box-shadow: 0 1px 3px rgba(0,0,0,.25);
+  top: 0;
+  z-index: 1;
+  left: 0;
+  right: 0;
+}
+
+.header,
+nav a {
+  height: 80px;
+}
+
+.header:before {
+  border-bottom: 2px solid rgba(0,0,0,.1);
+  border-top: 2px solid rgba(255,255,255,.5);
+  content: "";
+  position: absolute;
+  top: 78px;
+  width: 100%;
+  z-index: 1;
+}
+
+nav a {
+  border: 0;
+  color: #999;
+  font-size: 16px;
+  font-weight: 500;
+  padding: 0 20px;
+}
+
+nav a:last-child {
+  padding-right: 0;
+}
+
+nav a:hover {
+  color: #2b8;
+}
+
+[data-hash="#benchmarks"] a[href="#benchmarks"],
+[data-hash="#faq"] a[href="#faq"],
+[data-hash="#resources"] a[href="#resources"] {
+  color: #286;
+  font-weight: bold;
+}
+
+a.logo {
+  border: 0;
+  color: #222;
+  padding: 0 0 0 155px;
+  position: relative;
+}
+
+a.logo:before {
+  background: url(../img/iceberg.svg) no-repeat;
+  background-size: contain;
+  content: "";
+  left: 0;
+  top: 26px;
+  min-height: 250px;
+  position: absolute;
+  width: 170px;
+}
+
+.massive {
+  font-size: 48px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+masthead {
+  background: #57c;
+  color: #fff;
+  display: block;
+}
+
+masthead a {
+  border-bottom: 3px solid rgba(102,255,255,.25);
+  color: #cff;
+}
+
+masthead a:hover {
+  border-bottom: 3px solid rgba(102,255,255,.5);
+  color: #6ff;
+}
+
+.wrap {
+  background-repeat: no-repeat;
+  font-weight: 300;
+  margin: 0 auto;
+  max-width: 1200px;
+  width: 80%;
+}
+
+.wrap-juicy {
+  padding: 30px 0;
+}
+
+.benchmarks .wrap-juicy {
+  background: #fff;
+  border: 30px solid #248;
+  border-width: 30px 155px;
+  padding: 30px;
+}
+
+.wrap-centre {
+  text-align: center;
+}
+
+.wrap-dark p {
+  color: #eee;
+}
+
+.wrap-light p {
+  color: #999;
+}
+
+input, button, textarea {
+  font-family: inherit;
+}
+
+.btn {
+  background: #40dfc2;
+  border: 0;
+  border-radius: 4px;
+  box-shadow: inset 0 -1px 0 rgba(0,0,0,.1);
+  color: #fff;
+  cursor: pointer;
+  display: inline-block;
+  font: 400 14px/24px "Source Sans Pro", sans-serif;
+  min-width: 80px;
+  padding: 2px 15px;
+  text-align: center;
+}
+.btn:hover {
+  background: #1ba088;
+}
+.btn.disabled,
+.btn[disabled] {
+  background: #9b9b9b;
+  cursor: not-allowed;
+}
+.btn.disabled:hover,
+.btn[disabled]:hover {
+  background: #656565;
+}
+.btn-cta {
+  font-size: 18px;
+  line-height: 28px;
+  min-width: 200px;
+  padding: 10px 15px;
+}
+.btn:hover {
+  box-shadow: inset 0 -1px 0 rgba(0,0,0,.35);
+  text-decoration: none;
+}
+.btn:focus {
+  box-shadow: 0 0 10px rgba(55,55,55,.75) inset;
+  color: rgba(255,255,255,.75);
+}
+.btn-small {
+  font-size: 10px;
+}
+.btn-medium {
+  font-size: 14px;
+  line-height: 1.85;
+  padding-left: 15px;
+  padding-right: 15px;
+}
+.btn.btn-round {
+  border-radius: 20px;
+}
+
+/* Active */
+.btn-cta:active {
+  background:red;
+}
+
+.btn:active,
+.btn-active,
+.btn-active:hover {
+  background: #ddd;
+  border: none;
+  box-shadow: 0 2px 4px rgba(0,0,0,.4) inset;
+  color: #555;
+  filter: none;
+  text-shadow: 0 1px 0 rgba(255,255,255,.8);
+}
+
+/* Full */
+.btn-full {
+  width: 100%;
+}
+.btn-inline {
+  display: inline-block;
+}
+
+.benchmarks {
+  background: #248;
+}
+
+.faq {
+  background: #ffe;
+}
+
+.resources {
+  background: #fdd;
+}
+
+.footer {
+  background: #eee;
+}
+
+table {
+  margin: 15px 0;
+  table-layout: fixed;
+  text-align: left;
+  width: 100%;
+}
+
+tr, td, th {
+  vertical-align: middle;
+}
+
+tbody {
+  background-color: #f7f7f7;
+}
+
+.table-bordered {
+  border: 1px solid #ddd;
+  border-collapse: separate;
+  border-left: 0;
+  border-spacing: 0;
+  border-radius: 3px;
+}
+
+.table-bordered thead th:first-child {
+  border-top-left-radius: 3px;
+}
+
+.table-bordered thead th:last-child {
+  border-top-right-radius: 3px;
+}
+
+.table-bordered thead th {
+  background-color: #fff;
+  border-left: 1px solid #ddd;
+  border-bottom: 0;
+  padding: .5em;
+}
+
+.table-bordered td {
+  border: 1px solid #ddd;
+  border-width: 1px 0 0 1px;
+  padding: .5em;
+}
+
+.table-striped tbody tr:nth-child(even) {
+  background-color: #ececec;
+}
+
+.row-group,
+.table-striped tbody tr:nth-child(even).row-group {
+  background: rgb(221,238,255);  /* #def */
+}
+
+.row-pending {
+  color: rgba(0,0,0,.25);
+}
+
+/* Hide text in all cells other than the Benchmark title cell */
+.row-pending td + td,
+.row-pending td + td * {
+  color: transparent;
+}
+
+.row-group.row-pending,
+.table-striped tbody tr:nth-child(even).row-group.row-pending {
+  background: rgba(221,238,255,.25);
+}
+
+.cell-group-title {
+  font-weight: bold;
+}
+
+.cell-running {
+  background-color: #ffa;
+  font-style: italic;
+}
+
+.cell-number {
+  background-color: #bcf;
+  font-weight: bold;
+  text-align: right;
+}
+
+.cell-number ~ .cell-scale {
+  font-weight: bold;
+}
+
+.cell-scale {
+  text-align: left;
+}
+
+.cell-description {
+  color: #666;
+  font-size: 12px;
+  text-align: left;
+}
+
+small {
+  color: #999;
+  font-size: 11px;
+}
+
+.toggly {
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+}
+
+.toggly.visible {
+  opacity: 1;
+  pointer-events: auto;
+  visibility: visible;
+}
+
+.presentation-area {
+  display: none;
+}
+
+[data-running] .presentation-area {
+  display: block;
+}
+
+iframe {
+  border: 0;
+  height: 145px;
+  width: 100%;
+}
+
+.results-area {
+  margin-top: 10px;
+}
+
+.results-area h3 {
+  margin-top: 15px;
+}
+
+a.section-anchor {
+  border: 0;
+}
+
+h3 a.section-anchor,
+h3 a.section-anchor:link,
+h3 a.section-anchor:active,
+h3 a.section-anchor:visited {
+  color: inherit;
+}
+
+.section-anchor {
+  display: block;
+  outline: 0;
+  margin-left: -50px;
+  padding-left: 50px;
+  position: relative;
+}
+
+.section-anchor:before {
+  color: #ccc;
+  content: "\00a7";
+  left: 0;
+  opacity: 0;
+  pointer-events: none;
+  position: absolute;
+  text-align: center;
+  transition: .15s opacity, .15s visibility;
+  visibility: hidden;
+  width: 50px;
+}
+
+.section-anchor:focus:before,
+.section-anchor:hover:before {
+  opacity: 1;
+  pointer-events: auto;
+  visibility: visible;
+}
+
+.section-anchor:focus:before {
+  color: #666;
+}

--- a/img/iceberg.svg
+++ b/img/iceberg.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="179px" height="330px" viewBox="0 0 179 330" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.1 (8751) - http://www.bohemiancoding.com/sketch -->
+    <title>Untitled 2</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <linearGradient x1="0%" y1="0%" x2="0%" y2="100%" id="linearGradient-1">
+            <stop stop-color="#E2FFFF" offset="0%"></stop>
+            <stop stop-color="#FFFFFF" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="0%" y1="0%" x2="0%" y2="100%" id="linearGradient-2">
+            <stop stop-color="#E2FFFF" offset="0%"></stop>
+            <stop stop-color="#ABEEFF" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="0%" y1="0%" x2="0%" y2="100%" id="linearGradient-3">
+            <stop stop-color="#63B1FF" offset="0%"></stop>
+            <stop stop-color="#2E74E8" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="0%" y1="0%" x2="0%" y2="100%" id="linearGradient-4">
+            <stop stop-color="#63B1FF" offset="0%"></stop>
+            <stop stop-color="#89CCFF" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="0%" y1="0%" x2="0%" y2="100%" id="linearGradient-5">
+            <stop stop-color="#FFFFFF" offset="0%"></stop>
+            <stop stop-color="#FFFFFF" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="0%" y1="0%" x2="0%" y2="100%" id="linearGradient-6">
+            <stop stop-color="#3E92E3" offset="0%"></stop>
+            <stop stop-color="#75AFE6" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="0%" y1="0%" x2="0%" y2="100%" id="linearGradient-7">
+            <stop stop-color="#184590" offset="0%"></stop>
+            <stop stop-color="#0F3676" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="0%" y1="0%" x2="0%" y2="100%" id="linearGradient-8">
+            <stop stop-color="#2C8FFB" offset="0%"></stop>
+            <stop stop-color="#1761D7" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="0%" y1="0%" x2="0%" y2="100%" id="linearGradient-9">
+            <stop stop-color="#1851AF" offset="0%"></stop>
+            <stop stop-color="#1761D7" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="0%" y1="0%" x2="0%" y2="100%" id="linearGradient-10">
+            <stop stop-color="#184590" offset="0%"></stop>
+            <stop stop-color="#15356E" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="0%" y1="0%" x2="0%" y2="100%" id="linearGradient-11">
+            <stop stop-color="#184590" offset="0%"></stop>
+            <stop stop-color="#1761D7" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="iceberg" sketch:type="MSLayerGroup" transform="translate(-84.000000, 0.000000)">
+            <path d="M257.3669,71.3628 L84.4567,54.4301 L100.4806,71.409 L257.3669,71.3628 L257.3669,71.3628 Z" id="path22" sketch:type="MSShapeGroup"></path>
+            <path d="M215.8254,0.0696 L152.66,60.2144 L226.8331,55.1233 L215.8254,0.0696 L215.8254,0.0696 Z" id="path32" fill="url(#linearGradient-1)" sketch:type="MSShapeGroup"></path>
+            <path d="M215.8254,0.0696 L262.5173,37.0043 L257.3669,71.3628 L226.8331,55.1233 L215.8254,0.0696 L215.8254,0.0696 Z" id="path42" fill="url(#linearGradient-2)" sketch:type="MSShapeGroup"></path>
+            <path d="M84.4567,54.4301 L100.4806,71.409 L87.195,71.409 L84.4567,54.4301 L84.4567,54.4301 Z" id="path44" fill="#3C8FFF" sketch:type="MSShapeGroup"></path>
+            <path d="M152.66,60.2144 L150.3852,71.409 L100.4806,71.409 L84.4567,54.4301 L152.66,60.2144 L152.66,60.2144 Z" id="path54" fill="url(#linearGradient-1)" sketch:type="MSShapeGroup"></path>
+            <path d="M215.8254,0.0696 L152.66,60.2144 L84.4567,54.4301 L150.8061,40.4674 L215.8254,0.0696 L215.8254,0.0696 Z" id="path64" fill="url(#linearGradient-3)" sketch:type="MSShapeGroup"></path>
+            <path d="M226.8331,55.1233 L257.3669,71.3628 L217.2205,71.3747 L226.8331,55.1233 L226.8331,55.1233 Z" id="path74" fill="url(#linearGradient-4)" sketch:type="MSShapeGroup"></path>
+            <path d="M156.333,71.409 L152.66,60.2144 L181.0939,71.3636 L156.333,71.409 L156.333,71.409 Z" id="path84" fill="url(#linearGradient-3)" sketch:type="MSShapeGroup"></path>
+            <path d="M84.4567,54.4301 L100.4806,71.409 L87.195,71.409 L84.4567,54.4301 L84.4567,54.4301 Z" id="path86" fill="#2E74E8" sketch:type="MSShapeGroup"></path>
+            <path d="M150.8061,40.4674 L152.66,60.2144 L84.4567,54.4301 L150.8061,40.4674 L150.8061,40.4674 Z" id="path96" fill="url(#linearGradient-4)" sketch:type="MSShapeGroup"></path>
+            <path d="M262.5173,37.0043 L226.8339,55.1233 L257.3677,71.3628 L262.5173,37.0043 L262.5173,37.0043 Z" id="path106" fill="url(#linearGradient-5)" sketch:type="MSShapeGroup"></path>
+            <path d="M156.333,71.409 L152.66,60.2144 L150.3852,71.409 L156.333,71.409 L156.333,71.409 Z" id="path116" fill="url(#linearGradient-2)" sketch:type="MSShapeGroup"></path>
+            <path d="M257.3669,71.3628 L256.7573,131.148 L210.1614,177.9336 L210.2603,82.7979 L257.3669,71.3628 L257.3669,71.3628 Z" id="path126" fill="url(#linearGradient-6)" sketch:type="MSShapeGroup"></path>
+            <path d="M140.2916,113.5914 L121.7349,233.524 L96.8635,131.3663 L140.2916,113.5914 L140.2916,113.5914 Z" id="path136" fill="url(#linearGradient-7)" sketch:type="MSShapeGroup"></path>
+            <path d="M150.3852,71.409 L140.2916,113.5914 L100.4806,71.409 L150.3852,71.409 L150.3852,71.409 Z" id="path146" fill="url(#linearGradient-8)" sketch:type="MSShapeGroup"></path>
+            <path d="M210.1605,177.9336 L224.5755,220.4284 L195.568,330.0112 L210.1605,177.9336 L210.1605,177.9336 Z" id="path156" fill="url(#linearGradient-8)" sketch:type="MSShapeGroup"></path>
+            <path d="M257.3669,71.3628 L210.2603,82.7979 L217.2205,71.3756 L257.3669,71.3628 L257.3669,71.3628 Z" id="path166" fill="url(#linearGradient-8)" sketch:type="MSShapeGroup"></path>
+            <path d="M177.8885,138.0108 L156.333,71.409 L181.0939,71.3636 L210.2603,82.7979 L177.8885,138.0108 L177.8885,138.0108 Z" id="path176" fill="url(#linearGradient-9)" sketch:type="MSShapeGroup"></path>
+            <path d="M177.8876,138.0108 L140.2916,113.5914 L121.7349,233.524 L177.8876,138.0108 L177.8876,138.0108 Z" id="path186" fill="url(#linearGradient-8)" sketch:type="MSShapeGroup"></path>
+            <path d="M210.2603,82.7979 L121.7349,233.524 L210.1614,177.9336 L210.2603,82.7979 L210.2603,82.7979 Z" id="path196" fill="url(#linearGradient-10)" sketch:type="MSShapeGroup"></path>
+            <path d="M100.4806,71.409 L140.2916,113.5914 L96.8635,131.3663 L87.195,71.409 L100.4806,71.409 L100.4806,71.409 Z" id="path206" fill="url(#linearGradient-10)" sketch:type="MSShapeGroup"></path>
+            <path d="M257.3669,71.3628 L210.2603,82.7979 L256.7573,131.148 L257.3669,71.3628 L257.3669,71.3628 Z" id="path216" fill="url(#linearGradient-9)" sketch:type="MSShapeGroup"></path>
+            <path d="M140.2916,113.5914 L177.8885,138.0108 L156.333,71.409 L150.3852,71.409 L140.2916,113.5914 L140.2916,113.5914 Z" id="path226" fill="url(#linearGradient-6)" sketch:type="MSShapeGroup"></path>
+            <path d="M120.817,233.4076 L210.1614,177.9336 L150.7273,270.9029 L120.817,233.4076 L120.817,233.4076 Z" id="path236" fill="url(#linearGradient-11)" sketch:type="MSShapeGroup"></path>
+            <path d="M150.7273,270.9029 L195.5681,330.0112 L210.1597,177.9336 L150.7273,270.9029 L150.7273,270.9029 Z" id="path246" fill="url(#linearGradient-10)" sketch:type="MSShapeGroup"></path>
+            <path d="M256.7573,131.148 L224.5755,220.4284 L210.1614,177.9336 L256.7573,131.148 L256.7573,131.148 Z" id="path256" fill="url(#linearGradient-6)" sketch:type="MSShapeGroup"></path>
+            <path d="M152.6599,60.2143 L226.833,55.1233 L217.2204,71.3746 L181.1512,71.3854 L152.6599,60.2143 L152.6599,60.2143 Z" id="path266" fill="url(#linearGradient-3)" sketch:type="MSShapeGroup"></path>
+            <path d="M210.2602,82.7979 L217.2204,71.3746 L181.1512,71.3854 L210.2602,82.7979 L210.2602,82.7979 Z" id="path276" fill="url(#linearGradient-8)" sketch:type="MSShapeGroup"></path>
+        </g>
+    </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -3,223 +3,199 @@
   <head>
     <meta charset="utf-8">
     <title>MASSIVE - the asm.js benchmark</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="">
-    <meta name="author" content="">
-
+    <meta aria-hidden="true" class="section-anchor" name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta aria-hidden="true" class="section-anchor" name="description" content="">
+    <meta aria-hidden="true" class="section-anchor" name="author" content="">
     <!-- Le styles -->
-    <link href="css/bootstrap.min.css" rel="stylesheet">
-    <style>
-      body {
-        padding-top: 60px; /* 60px to make the container go all the way to the bottom of the topbar */
-      }
-      #presentation-area {
-        width: 100%;
-        height: 180px;
-      }
-      #responsiveness-frame {
-        width: 100%;
-        height: 90%;
-        border: none;
-      }
-    </style>
-    <link href="css/bootstrap-responsive.min.css" rel="stylesheet">
-
-    <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
-    <!--[if lt IE 9]>
-      <script src="js/html5shiv.js"></script>
-    <![endif]-->
+    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700" rel="stylesheet" type="text/css">
+    <link href="css/main.css" rel="stylesheet">
   </head>
-
   <body>
-
-    <div class="navbar navbar-inverse navbar-fixed-top">
-      <div class="navbar-inner">
-        <div class="container">
-          <button type="button" class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-          <a class="brand" href="#">MASSIVE</a>
-          <div class="nav-collapse collapse">
-            <ul class="nav">
-              <!--li class="active"><a href="massive.html">Benchmarks</a></li-->
-            </ul>
-          </div><!--/.nav-collapse -->
-        </div>
+    <header class="header">
+      <div class="wrap flex">
+        <a href="" class="logo flex flex-1">
+          <big class="massive flex vcentre">Massive</big>
+        </a>
+        <nav class="flex">
+          <a href="#benchmarks" class="flex vcentre">Benchmarks</a>
+          <a href="#faq" class="flex vcentre">FAQ</a>
+          <a href="#resources" class="flex vcentre">Resources</a>
+          <a href="https://github.com/kripken/Massive" class="flex vcentre">Source Code</a>
+        </nav>
       </div>
-    </div>
-
-    <div class="container">
-
-      <div class="hero-unit">
-        <img src="logo/Massive.png" style="border: 1px solid black; box-shadow: 10px 5px 10px #888; margin-bottom: 0.5em">
-        <center><h2 style="color: #555; font-size: 2.5em">the <span style="color: #000">asm.js</span> benchmark</h1></center>
-        <h4>v0.3.1 (beta)</h4>
-        <div id="blurb">
-          <br>
-          <p>Massive is a JavaScript benchmark that focuses on large, real-world C++ codebases compiled into <a href="http://asmjs.org">asm.js</a> using <a href="http://emscripten.org">Emscripten</a>. This is just one pattern of JavaScript among many on the web, but is very important for things like games, and unique in that the generated JavaScript is often very large (much larger than typical JavaScript benchmarks), which is the motivation for a new benchmark.</p>
-          <br>
-        </div>
-        <p><a href="#" class="btn btn-primary btn-large btn-run" id="btn-run">Run the benchmark now! &raquo;</a></p>
-        <p id="warning"><small>(Benchmark will take a while to run, and some browsers may become less responsive for part of that time.)</small></p>
-        <div id="copy_results" hidden=1>
-          <center><button type="button" class="btn btn-copy" id="btn-copy">Copy results (so you can view them again later)</button></center>
-        </div>
-        <p><center style="font-weight: bold; color: #b31">This benchmark is a work in progress - it is NOT ready yet. <a style="color: #510" href="https://github.com/kripken/Massive/issues">Feedback</a> is welcome!</center></p>
+    </header>
+    <masthead id="intro" class="masthead-intro">
+      <div class="wrap wrap-juicy wrap-dark">
+        <big class="slogan">the <a href="http://asmjs.org">asm.js</a> benchmark</big>
       </div>
+    </masthead>
+    <section id="benchmarks" class="benchmarks">
+      <div class="wrap wrap-juicy wrap-light wrap-centre">
+        <h2>Run the benchmarks now</h2>
+        <p>Benchmarks will take a while to run, and some browsers may become less responsive for part of that time.</p>
+        <p><a class="btn btn-cta btn-run" id="btn-run">Run</a></p>
+        <p><button type="button" class="btn btn-paste" id="btn-paste">Enter data copied from another run</button></p>
 
-      <div class="row-fluid" id="results_area" hidden=1>
-        <div id="presentation-area"></div>
-        <div class="span">
+        <div id="above-results-area"></div>
+        <div class="hidden results-area" id="results-area">
+          <div class="toggly visible presentation-area" id="presentation-area"></div>
           <h3>Individual Benchmark Results</h3>
-            <table class="table table-striped table-bordered table-hover">
-              <thead>
-                <tr>
-                  <th>Benchmark</th>
-                  <th>Result</th>
-                  <th>Scale</th>
-                  <th>What it measures</th>
-                  <!--th>Normalized score<br>(higher is better)</th-->
-                </tr>
-              </thead>
-              <tbody id="table_body">
-              </tbody>
-            </table>
+          <table class="table-bordered table-striped">
+            <thead>
+              <tr>
+                <th>Benchmark</th>
+                <th>Result</th>
+                <th>Scale</th>
+                <th>What it measures</th>
+                <!--th>Normalized score<br>(higher is better)</th-->
+              </tr>
+            </thead>
+            <tbody id="table-body">
+            </tbody>
+          </table>
+          <div class="hidden" id="copy-results">
+            <button type="button" class="btn btn-copy" id="btn-copy">Copy results</button><br>
+            <small>(so you can view them again later)</small>
+          </div>
         </div>
       </div>
-
-<script>
-function toggleFAQ() {
-  var button = document.getElementById('faq-button');
-  var faq = document.getElementById('faq');
-  if (faq.style.display === 'none') {
-    faq.style.display = 'block';
-    button.innerHTML = 'Hide';
-  } else {
-    faq.style.display = 'none';
-    button.innerHTML = 'Show';
-  }
-}
-function ensureFAQ() {
-  if (document.getElementById('faq').style.display === 'none') toggleFAQ();
-}
-</script>
-
-      <div class="row-fluid">
-        <div class="span">
-          <h3>
-            FAQ
-            <button id="faq-button" type="button" class="btn" onclick="toggleFAQ()">Show</button>
-          </h3>
-        </div>
-        <div id="faq" style="display: none">
-          <h4>Why make a new benchmark?</h4>
+    </section>
+    <section id="faq" class="faq">
+      <div class="wrap wrap-juicy prose">
+        <h2>FAQ</h2>
+        <h3 class="section-heading"><a aria-hidden="true" class="section-anchor" name="faq-why_make_a_new_benchmark" href="#faq-why_make_a_new_benchmark">Why make a new benchmark?</a></h3>
+        <div class="answer">
           <p>asm.js appears in one test in <a href="https://developers.google.com/octane/">Octane</a>, and in several
-             tests in <a href="http://browserbench.org/JetStream/">JetStream</a>, which is great, but several aspects of asm.js performance are
-             not fully measured in those. In particular, asm.js
-             often appears as large (you might even say <b>massive</b>) source files, which can have different performance characteristics than the typical
-             small programs appearing in most benchmarks. For example, a very large codebase may contain very large functions,
-             which due to their size are difficult to optimize efficiently (either not fully optimized, or optimized slowly in a noticeable way),
-             or just the sheer number of functions may be very high and cause the browser to pause as the codebase is parsed and starts to execute.
-             Such very large codebases can therefore bring new challenges to JavaScript engines (or rather, more extreme versions of familiar challenges),
-             and it is important to measure performance on them because they are showing up with increasing frequency on the web (for example,
-             as native plugins are fading out, game engine companies like <a href="http://unity3d.com/">Unity</a> and
-             <a href="http://unrealengine.com/">Epic</a> are starting to compile their large codebases to asm.js).
-             For these reasons, the Massive benchmark includes several very large codebases (Poppler, SQLite, etc.), and measures throughput as well as
-             responsiveness, variability and startup time (see details below).</p>
-          <h4>How does this relate to the Emscripten benchmark suite - what does this offer over that?</h4>
+           tests in <a href="http://browserbench.org/JetStream/">JetStream</a>, which is great, but several aspects of asm.js performance are
+           not fully measured in those. In particular, asm.js
+           often appears as large (you might even say <b>massive</b>) source files, which can have different performance characteristics than the typical
+           small programs appearing in most benchmarks. For example, a very large codebase may contain very large functions,
+           which due to their size are difficult to optimize efficiently (either not fully optimized, or optimized slowly in a noticeable way),
+           or just the sheer number of functions may be very high and cause the browser to pause as the codebase is parsed and starts to execute.
+           Such very large codebases can therefore bring new challenges to JavaScript engines (or rather, more extreme versions of familiar challenges),
+           and it is important to measure performance on them because they are showing up with increasing frequency on the web (for example,
+           as native plugins are fading out, game engine companies like <a href="http://unity3d.com/">Unity</a> and
+           <a href="http://unrealengine.com/">Epic</a> are starting to compile their large codebases to asm.js).
+           For these reasons, the Massive benchmark includes several very large codebases (Poppler, SQLite, etc.), and measures throughput as well as
+           responsiveness, variability and startup time (see details below).</p>
+        </div>
+        <h3 class="section-heading"><a aria-hidden="true" class="section-anchor" name="faq-how_does_this_relate_to_Emscripten" href="#faq-how_does_this_relate_to_Emscripten">How does this relate to the Emscripten benchmark suite? What does this offer over that?</a></h3>
+        <div class="answer">
           <p>The <a href="http://kripken.github.io/embenchen/">Emscripten benchmark suite</a> evolved over time in order
-             to benchmark Emscripten itself, and therefore mainly focused on throughput, and is runnable in both shell and
-             browser. Massive, on the other hand, tests not just
-             throughput but also browser responsiveness and other factors that only make sense when running in a browser, things
-             not measured by the Emscripten benchmark suite (or by the main JavaScript benchmarks).</p>
-          <a name="explanations"></a>
-          <h4>What do the categories ("Main Thread Responsiveness", "Throughput", "Preparation", and "Variance") mean?</h4>
+           to benchmark Emscripten itself, and therefore mainly focused on throughput, and is runnable in both shell and
+           browser. Massive, on the other hand, tests not just
+           throughput but also browser responsiveness and other factors that only make sense when running in a browser, things
+           not measured by the Emscripten benchmark suite (or by the main JavaScript benchmarks).</p>
+        </div>
+        <a aria-hidden="true" name="faq-explanations"></a>
+        <h3 class="section-heading"><a aria-hidden="true" class="section-anchor" name="faq-what_do_the_categories_mean" href="#faq-what_do_the_categories_mean">What do the categories ("Main Thread Responsiveness", "Throughput", "Preparation", and "Variance") mean?</a></h3>
+        <div class="answer">
           <p><b>Main Thread Responsiveness</b> measures the user experience as a large codebase is loaded. What is tested is whether
-             the main thread stalls as the codebase is prepared and executed for a short while. The score here can be improved
-             by parsing the code off the main thread, for example. This does <b>not</b> measure how much time is spent,
-             but only how responsive or unresponsive the user experience is (how much time is spent is measured by
-             Preparation, and to some extent Throughput). Technically, we measure responsiveness by seeing if events on
-             the main thread execute at the proper interval (as when the main thread stalls, it stalls both the user
-             experience and other events).</p>
+           the main thread stalls as the codebase is prepared and executed for a short while. The score here can be improved
+           by parsing the code off the main thread, for example. This does <b>not</b> measure how much time is spent,
+           but only how responsive or unresponsive the user experience is (how much time is spent is measured by
+           Preparation, and to some extent Throughput). Technically, we measure responsiveness by seeing if events on
+           the main thread execute at the proper interval (as when the main thread stalls, it stalls both the user
+           experience and other events).</p>
           <p><b>Throughput</b> measures how fast a large computational workload runs. This is what is typically measured by
-             benchmarks. Massive's throughput tests focus on very large real-world codebases.</p>
+           benchmarks. Massive's throughput tests focus on very large real-world codebases.</p>
           <p><b>Preparation</b> measures how long (in wall time) is spent to get a codebase ready to execute, before
-             executing any of it. This measures how much
-             time passes between adding a script tag with that code and being able to call the code (this may or may not
-             cause a user-noticeable pause, depending on whether it is parsed on or off the main thread; Main Thread Responsiveness
-             tests that aspect). "Preparation" is basically all the time before code is actually able to run; that may include
-             parsing, conversion to bitcode, JIT compilation, etc., depending on the JS engine.</p>
+           executing any of it. This measures how much
+           time passes between adding a script tag with that code and being able to call the code (this may or may not
+           cause a user-noticeable pause, depending on whether it is parsed on or off the main thread; Main Thread Responsiveness
+           tests that aspect). "Preparation" is basically all the time before code is actually able to run; that may include
+           parsing, conversion to bitcode, JIT compilation, etc., depending on the JS engine.</p>
           <p><b>Variance</b> measures how variable the frame rate is in an application that needs to run in each frame
-             (this is important in things like games, which must finish all they need every 1/60 of a second, in order to be
-             smooth). Specifically, we run many frames and then calculate the statistical variance and worst case. Note that
-             one VM might have a much faster overall frame rate than another, but also more variance: in general, given two
-             VMs with the same average, the one with less variance is "better" since it's smoother. But given a different mean,
-             things are less clear (perhaps we are happy to get some average slowdown in order to reduce variance which can
-             cause noticable but rare pauses?). Hence we measure variance separately from throughput (which is a measurement of the total
-             speed, and is proportional to the average).</p>
-          <h4>How consistent are these results between runs of the benchmark suite?</h4>
+           (this is important in things like games, which must finish all they need every 1/60 of a second, in order to be
+           smooth). Specifically, we run many frames and then calculate the statistical variance and worst case. Note that
+           one VM might have a much faster overall frame rate than another, but also more variance: in general, given two
+           VMs with the same average, the one with less variance is "better" since it's smoother. But given a different mean,
+           things are less clear (perhaps we are happy to get some average slowdown in order to reduce variance which can
+           cause noticable but rare pauses?). Hence we measure variance separately from throughput (which is a measurement of the total
+           speed, and is proportional to the average).</p>
+        </div>
+        <h3 class="section-heading"><a aria-hidden="true" class="section-anchor" name="faq-how_consistent_are_these_results" href="#faq-how_consistent_are_these_results">How consistent are these results between runs of the benchmark suite?</a></h3>
+        <div class="answer">
           <p>Most of the tests, in particular the throughput ones, are generally very consistent, as we run a deterministic workload
-             in a web worker, which minimizes outside noise. We also run a few repetitions and average the results. However, in particular
-             the Main Thread Responsiveness tests need to run on the main thread, and they involve DOM events like adding a script tag,
-             setInterval, etc., which can be fairly variable. We run a larger amount of repetitions on those tests to average out the
-             noise, but even so they appear to be less consistent between runs on some browsers.</p>
-          <a name="toovariable"></a>
+           in a web worker, which minimizes outside noise. We also run a few repetitions and average the results. However, in particular
+           the Main Thread Responsiveness tests need to run on the main thread, and they involve DOM events like adding a script tag,
+           setInterval, etc., which can be fairly variable. We run a larger amount of repetitions on those tests to average out the
+           noise, but even so they appear to be less consistent between runs on some browsers.</p>
+          <a aria-hidden="true" name="faq-toovariable"></a>
           <p>When we see the results of a test are too variable, we mark it with <b>"(±X%!)"</b> next to the score. The cause of such variability
-             might be something else on your machine (perhaps a background indexing service happend to use a CPU core during a test, etc.),
-             or it might be that the browser behaves unpredictably for some reason.</p>
-          <h4>What code is being tested in these benchmarks?</h4>
-          <p>All the benchmarks here are from real-world C or C++ codebases:
-            <ul>
-              <li><b>Box2D</b>: A 2D physics engine, used in many games, for example Angry Birds. Stresses
-                                floating-point processing performance. The workload is based on
-                                <a href="https://github.com/joelgwebber/bench2d/">jgw's bench2D</a>. (~30KLOC)</li>
-              <li><b>Lua</b>: A script language that is used in many games as well as on Wikipedia. Here the
-                              entire Lua VM is compiled down to JavaScript, including interpreter, garbage
-                              collector, etc. The workloads used are the scimark and binarytrees benchmarks,
-                              which test raw computation and garbage collection, respectively. (~16KLOC)</li>
-              <li><b>Poppler</b>: A PDF rendering engine, used by many applications, for example LibreOffice.
-                                  Rendering PDFs requires many capabilities (font rendering, graphics, etc.),
-                                  making this the largest of the codebases tested here, especially since it is
-                                  built together with the FreeType font rendering library. The workload is
-                                  Lawrence Lessig's "Free Culture". (~250KLOC)</li>
-              <li><b>SQLite</b>: A complete transactional SQL database engine. Parsing and executing SQL
-                                 queries is done using a large interpreter-loop type function, which is
-                                 challenging to optimize. The workload is the SQLite speedtest1.c benchmark,
-                                 which SQLite devs constructed to represent real-world usage patterns. (~128KLOC)</li>
-            </ul>
-            All of these codebases are open source, so you can build and inspect them yourself (the build
-            tool, <a href="http://emscripten.org">Emscripten</a>, is of course open source as well).
-          </p>
+            might be something else on your machine (perhaps a background indexing service happend to use a CPU core during a test, etc.),
+            or it might be that the browser behaves unpredictably for some reason.</p>
+        </div>
+        <h3 class="section-heading"><a aria-hidden="true" class="section-anchor" name="faq-what_code_is_being_tested" href="#faq-what_code_is_being_tested">What code is being tested in these benchmarks?</a></h3>
+        <div class="answer">
+          <p>All the benchmarks here are from real-world C or C++ codebases:</p>
+          <ul>
+            <li><b>Box2D</b>: A 2D physics engine, used in many games, for example Angry Birds. Stresses
+                              floating-point processing performance. The workload is based on
+                              <a href="https://github.com/joelgwebber/bench2d/">jgw's bench2D</a>. (~30KLOC)</li>
+            <li><b>Lua</b>: A script language that is used in many games as well as on Wikipedia. Here the
+                            entire Lua VM is compiled down to JavaScript, including interpreter, garbage
+                            collector, etc. The workloads used are the scimark and binarytrees benchmarks,
+                            which test raw computation and garbage collection, respectively. (~16KLOC)</li>
+            <li><b>Poppler</b>: A PDF rendering engine, used by many applications, for example LibreOffice.
+                                Rendering PDFs requires many capabilities (font rendering, graphics, etc.),
+                                making this the largest of the codebases tested here, especially since it is
+                                built together with the FreeType font rendering library. The workload is
+                                Lawrence Lessig's "Free Culture". (~250KLOC)</li>
+            <li><b>SQLite</b>: A complete transactional SQL database engine. Parsing and executing SQL
+                               queries is done using a large interpreter-loop type function, which is
+                               challenging to optimize. The workload is the SQLite speedtest1.c benchmark,
+                               which SQLite devs constructed to represent real-world usage patterns. (~128KLOC)</li>
+          </ul>
+          <p>All of these codebases are open source, so you can build and inspect them yourself (the build
+          tool, <a href="http://emscripten.org">Emscripten</a>, is of course open source as well).</p>
           <p>Note that the KLOC numbers mentioned above do not include system libraries like libc and libc++,
              the necessary parts of which are necessarily included in the benchmarks.</p>
-          <h4>How long does Massive take to run?</h4>
-          <p>Generally quite a while, as it is designed to execute fixed workloads of sufficient length to
-             measure real-world performance on large applications. How long it takes will depend on the machine and
-             browser, of course, but you can probably expect it to take at least a few minutes (on a desktop or laptop
-             machine; a mobile device may take much more). Massive should not lock up your
-             browser as it runs, however - except for the Main Thread Responsiveness tests, which run first, benchmarks
-             are run in web workers (and even the Main Thread Responsiveness tests should not reduce responsiveness
-             very much). Note that results of individual benchmarks show up when ready, so you can view those
-             before all of Massive is complete.</p>
-          <h4>Can I run just an individual benchmark, for testing purposes?</h4>
-          <p>Sure, use a URL like <code>index.html?box2d-throughput,box2d-throughput-f32</code> to run just those benchmarks.</p>
         </div>
-        <br>
-        <div class="span">
-          <center><button type="button" class="btn btn-paste" id="btn-paste">Enter data copied from another run</button></center>
-          <br>
+        <h3 class="section-heading"><a aria-hidden="true" class="section-anchor" name="faq-how_long_does_Massive_take_to_run" href="#faq-how_long_does_Massive_take_to_run">How long does Massive take to run?</a></h3>
+        <div class="answer">
+          <p>Generally quite a while, as it is designed to execute fixed workloads of sufficient length to
+           measure real-world performance on large applications. How long it takes will depend on the machine and
+           browser, of course, but you can probably expect it to take at least a few minutes (on a desktop or laptop
+           machine; a mobile device may take much more). Massive should not lock up your
+           browser as it runs, however - except for the Main Thread Responsiveness tests, which run first, benchmarks
+           are run in web workers (and even the Main Thread Responsiveness tests should not reduce responsiveness
+           very much). Note that results of individual benchmarks show up when ready, so you can view those
+           before all of Massive is complete.</p>
+        </div>
+        <h3 class="section-heading"><a aria-hidden="true" class="section-anchor" name="faq-can_I_run_just_an_individual_benchmark" href="#faq-can_I_run_just_an_individual_benchmark">Can I run just an individual benchmark, for testing purposes?</a></h3>
+        <div class="answer">
+          <p>Sure, use a URL like <a href="index.html?box2d-throughput,box2d-throughput-f32"><code>index.html?box2d-throughput,box2d-throughput-f32</code></a> to run just those benchmarks.</p>
         </div>
       </div>
+    </section>
+    <section id="resources" class="resources">
+      <div class="wrap wrap-juicy prose">
+        <h2>Resources</h2>
+        <h3>Massive</a></h3>
+        <ul>
+          <li><a href="https://github.com/kripken/Massive">Source code</a></li>
+        </ul>
 
-    </div> <!-- /container -->
+        <h3>asm.js</a></h3>
+        <ul>
+          <li><a href="https://github.com/dherman/asm.js">Source code</a></li>
+        </ul>
 
+        <h3>Emscripten</a></h3>
+        <ul>
+          <li><a href="https://github.com/kripken/emscripten">Source code</a></li>
+          <li><a href="https://github.com/kripken/emscripten/wiki/Porting-Examples-and-Demos">Demos and Examples</a></li>
+          <li><a href="https://github.com/kripken/emscripten/wiki">Wiki</a></li>
+          <li><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Emscripten">MDN</a></li>
+        </ul>
+      </div>
+    </section>
+    <footer id="footer" class="footer">
+      <div class="wrap wrap-juicy">
+        <p>v0.3.1 (beta)</p>
+      </div>
+    </footer>
     <script src="driver.js"></script>
-
-    <a href="https://github.com/kripken/Massive"><img style="position: absolute; top: 35px; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
-
   </body>
 </html>
-

--- a/responsiveness.html
+++ b/responsiveness.html
@@ -5,23 +5,23 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>Emscripten-Generated Code</title>
     <style>
-      .emscripten { padding-right: 0; margin-left: auto; margin-right: auto; display: block; }
-      textarea.emscripten { font-family: monospace; width: 80%; }
+      * { margin: 0; padding: 0; }
+      body { font-family: monospace; padding: 10px; }
+      p { margin-bottom: 10px; }
+      textarea { font: inherit; font-size: 30pt; font-weight: bold; }
+      .emscripten { display: block; padding-right: 0; margin: 0 auto; }
+      textarea.emscripten { width: 80%; }
       div.emscripten { text-align: center; }
       div.emscripten_border { border: 1px solid black; }
       /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
       canvas.emscripten { border: 0px none; }
-      textarea {
-        font-size: 30pt;
-        font-weight: bold;
-      }
     </style>
   </head>
   <body>
     <p>An 'X' should move around, indicating responsiveness (after download, which is not counted)</p>
-    <textarea id="spinner" cols=20 maxlength=20 disabled=1>...</textarea>
+    <textarea id="spinner" cols="20" maxlength="20" disabled>...</textarea>
     <div class="emscripten">
-      <progress value="0" max="100" id="progress" hidden=1></progress>  
+      <progress value="0" max="100" id="progress" hidden></progress>
     </div>
     <div style="display:none">
       <div class="emscripten_border">
@@ -31,7 +31,7 @@
         <input type="checkbox" id="resize">Resize canvas
         <input type="checkbox" id="pointerLock" checked>Lock/hide mouse pointer
         &nbsp;&nbsp;&nbsp;
-        <input type="button" value="Fullscreen" onclick="Module.requestFullScreen(document.getElementById('pointerLock').checked, 
+        <input type="button" value="Fullscreen" onclick="Module.requestFullScreen(document.getElementById('pointerLock').checked,
                                                                                   document.getElementById('resize').checked)">
       </div>
       <textarea class="emscripten" id="output" rows="8"></textarea>


### PR DESCRIPTION
This PR adds on to the work done in #13. (I will close #13 when we're happy with things.)

First off, apologies for the delay.

This design sports a more politically correct logo, new colours, inclusion of Benchmark results table and "improved" styling, and tweaks to the FAQ section.
## screenshots

![screenshot 2014-10-22 04 54 14](https://cloud.githubusercontent.com/assets/203725/4735612/418d6540-59e2-11e4-89c3-a4fcca0dbbf8.png)
![screenshot 2014-10-22 04 54 45](https://cloud.githubusercontent.com/assets/203725/4735641/b743697e-59e2-11e4-97b1-645e00469640.png)
![screenshot 2014-10-22 05 00 02](https://cloud.githubusercontent.com/assets/203725/4735656/fcc4d014-59e2-11e4-9665-ddb3aba86116.png)
![screenshot 2014-10-22 04 54 56](https://cloud.githubusercontent.com/assets/203725/4735642/b744578a-59e2-11e4-98ca-c2ca41ae6ff8.png)
## what's left?
- Not pleased with the "Run the benchmarks now" section. Will try a few more colour/style treatments.
- Colours are a tad too blue, especially in the Benchmark results table. (And the yellow for "running…" I'm not super :smiley: with.)
- The FAQ :question: copy :copy: is a lot to read :book:. I didn't try trimming the text yet, but I've toyed :car:  with two/three columns, but things became too crowded to read.
- Resources section can use some better styling. This was my own addition; I think it's worth linking to relevant libraries and documentation. But I do think maybe the links don't need a separate section; perhaps the links might be better served as links in a footer.
