### PR TITLE
Added filter to remove undefined elements.

### DIFF
--- a/driver.js
+++ b/driver.js
@@ -473,6 +473,12 @@ function run() {
             };
           }
         });
+
+        // We need to remove the 'undefined' elements
+        results = results.filter(function(res) {
+          return res != null
+        });
+
         results.push({'benchmark': 'score', 'result': finalResult});
 
         var xmlHttp = new XMLHttpRequest();


### PR DESCRIPTION
I'm working with Dan Minor on mozbench (https://github.com/dminor/mozbench).

In order to integrate Massive seemingly into mozbench, we need to remove 'undefined' elements form results. Those come from the 'jobs.map'.

I added a filter to remove those elements. 