### PR TITLE
Normalize results when using postToURL

### DIFF
--- a/driver.js
+++ b/driver.js
@@ -469,7 +469,7 @@ function run() {
           if ('calculate' in job) {
             return {
               'benchmark': job.benchmark,
-              'result': job.calculate().toFixed(3)
+              'result': normalize(job)
             };
           }
         });


### PR DESCRIPTION
Normalizing the output already happens when viewing the results.
Though there is some inconsistency and the results aren't normalized when making use of the postToURL feature.
